### PR TITLE
Fixes ipython/ipynb#31

### DIFF
--- a/ipynb/utils.py
+++ b/ipynb/utils.py
@@ -59,7 +59,8 @@ def filter_ast(module_ast):
                 return True
 
         if isinstance(node, ast.Assign):
-            return all([t.id.isupper() for t in node.targets])
+            return all([t.id.isupper() for t in node.targets if hasattr(t, 'id')]) \
+                and all([[e.id.isupper() for e in t.elts] for t in node.targets if hasattr(t, 'elts')])
 
         return False
 


### PR DESCRIPTION
Fixes bug interpreting tuple based assignment.

Example:

```
a, b = fn()
```

Previously this would result in the error described in ipython/ipynb#31. This fix correctly parses tuple based assignments as intended.