### PR TITLE
Fix for https://github.com/ipython/ipynb/pull/34#issuecomment-330024201

### DIFF
--- a/ipynb/utils.py
+++ b/ipynb/utils.py
@@ -58,9 +58,11 @@ def filter_ast(module_ast):
             if isinstance(node, an):
                 return True
 
+        # Recurse through Assign node LHS targets when an id is not specified,
+        # otherwise check that the id is uppercase
         if isinstance(node, ast.Assign):
-            return all([t.id.isupper() for t in node.targets if hasattr(t, 'id')]) \
-                and all([[e.id.isupper() for e in t.elts] for t in node.targets if hasattr(t, 'elts')])
+            return all([node_predicate(t) for t in node.targets if not hasattr(t, 'id')]) \
+                and all([t.id.isupper() for t in node.targets if hasattr(t, 'id')])
 
         return False
 


### PR DESCRIPTION
A fix for the case highlighted by @ebraminio in https://github.com/ipython/ipynb/pull/34#issuecomment-330024201:

`o = {}; o['a'] = 'a'`

The solution recurses through LHS targets when an `id` is not found at the current level for `.isupper()` assessment, and also better addresses the fix merged in https://github.com/ipython/ipynb/pull/34. 